### PR TITLE
DevEx: Retain LF line endings in Bash scripts on Windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Bash scripts must retain LF endings on Windows.
+*.sh text eol=lf


### PR DESCRIPTION
When running Git in Windows, it converts line endings to CRLF in the local file system and converts back to LF when pushing to GitHub, This PR tells Git to keep LF line endings in *.sh files in the local file system.

In particular, start.sh needs LF line endings in order for `npm run dev` to work on Windows when Git is run from Windows but `npm run dev` is run in WSL.