### PR TITLE
Fix use of global realms reference.

### DIFF
--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1238,9 +1238,9 @@ export class NetworkRealms extends EventTarget {
       _importPlayer();
 
       // migrate networked audio client
-      realms.migrateAudioRealm(oldHeadRealm, newHeadRealm);
+      this.migrateAudioRealm(oldHeadRealm, newHeadRealm);
 
-      await realms.sync();
+      await this.sync();
 
       // delete old
       // delete apps


### PR DESCRIPTION
There is no `realms` variable defined in the function or otherwise within network-realms.js. The original `realms` variable was actually that set in html-renderer.js:
```
window.realms = realms;
```
And this is the same object as `this` per the lines changed.