### PR TITLE
Remove unused sendChatMessage() method from audio-client code.

### DIFF
--- a/public/audio-client.mjs
+++ b/public/audio-client.mjs
@@ -238,15 +238,4 @@ export class NetworkedAudioClient extends EventTarget {
       debugger;
     }
   }
-
-  sendChatMessage(message) {
-    const buffer = zbencode({
-      method: UPDATE_METHODS.CHAT,
-      args: [
-        this.playerId,
-        message,
-      ],
-    });
-    this.ws.send(buffer);
-  }
 }


### PR DESCRIPTION
This looks like a cut-and-paste left-over from irc-client code.