### PR TITLE
Webaverse app integration

### DIFF
--- a/public/audio-client.mjs
+++ b/public/audio-client.mjs
@@ -238,15 +238,4 @@ export class NetworkedAudioClient extends EventTarget {
       debugger;
     }
   }
-
-  sendChatMessage(message) {
-    const buffer = zbencode({
-      method: UPDATE_METHODS.CHAT,
-      args: [
-        this.playerId,
-        message,
-      ],
-    });
-    this.ws.send(buffer);
-  }
 }

--- a/public/audio-client.mjs
+++ b/public/audio-client.mjs
@@ -40,6 +40,11 @@ const stopMediaStream = mediaStream => {
   }
 };
 
+export async function initAudioContext() {
+  const audioContext = await ensureAudioContext();
+  audioContext.resume();
+}
+
 export async function createMicrophoneSource() {
   const audioContext = await ensureAudioContext();
   audioContext.resume();

--- a/public/constants.js
+++ b/public/constants.js
@@ -1,3 +1,4 @@
 export const frameSize = 64;
 export const realmSize = 300;
 export const inventoryFrameSize = 30;
+export const MULTIPLAYER_PORT = 2222;

--- a/public/game.js
+++ b/public/game.js
@@ -45,7 +45,7 @@ export const startGame = async ({
   let remotePlayerCanvases = new Map();
   
   // realms
-  const realms = new NetworkRealms(playerId);
+  const realms = new NetworkRealms('scene', playerId);
   const realmCleanupFns = new Map();
   realms.addEventListener('realmconnecting', e => {
     const {realm} = e.data;

--- a/public/game.js
+++ b/public/game.js
@@ -401,7 +401,8 @@ export const startGame = async ({
         const newActionMap = realms.localPlayer.playerActions.addEntity(action, targetRealm);
 
         // remove from the old location (world)
-        collidedVirtualMap.remove();
+        //collidedVirtualMap.remove();
+        virtualWorld.worldApps.removeEntityAt(collidedVirtualMap.entityMap.arrayIndexId);
 
         // livehand
         const liveHandUpdate = targetRealm.dataClient.liveHandArrayMaps(
@@ -465,8 +466,10 @@ export const startGame = async ({
             // newPlayerApp.headTracker.setHeadRealm(targetRealm);
 
             // remove from the old location (player)
-            firstApp.remove();
-            firstAction.remove();
+            //firstApp.remove();
+            //firstAction.remove();
+            realms.localPlayer.playerApps.removeEntityAt(appId);
+            realms.localPlayer.playerActions.removeEntityAt(firstAction.arrayIndexId);
 
             const liveHandUpdate = targetRealm.dataClient.liveHandArrayMap(
               'worldApps',

--- a/public/game.js
+++ b/public/game.js
@@ -372,6 +372,8 @@ export const startGame = async ({
       const collidedVirtualMap = _getCollision();
       if (collidedVirtualMap) {
         // deadhand
+        // Is emitted by addEntity().
+        /*
         const sourceRealm = collidedVirtualMap.headTracker.getHeadRealm();
         const deadHandUpdate = sourceRealm.dataClient.deadHandArrayMaps(
           realms.localPlayer.playerApps.arrayId,
@@ -379,6 +381,7 @@ export const startGame = async ({
           realms.playerId,
         );
         sourceRealm.emitUpdate(deadHandUpdate);
+        */
         
         // track
         // collidedVirtualMap.setHeadTracker(realms.localPlayer.playerApps.headTracker);
@@ -405,12 +408,15 @@ export const startGame = async ({
         virtualWorld.worldApps.removeEntityAt(collidedVirtualMap.entityMap.arrayIndexId);
 
         // livehand
+        // Is emitted by addEntity().
+        /*
         const liveHandUpdate = targetRealm.dataClient.liveHandArrayMaps(
           realms.localPlayer.playerApps.arrayId,
           [collidedVirtualMap.entityMap.arrayIndexId],
           realms.playerId,
         );
         sourceRealm.emitUpdate(liveHandUpdate);
+        */
       } else {
         // console.log('got player apps', realms.localPlayer.playerApps.getSize());
         if (realms.localPlayer.playerActions.getSize() > 0) {
@@ -447,12 +453,16 @@ export const startGame = async ({
             // );
             // firstApp.headRealm.emitUpdate(deadHandUpdate);
             // new location: world
+            // deadhand
+            // Is emitted by addEntityAt().
+            /*
             const deadHandUpdate = targetRealm.dataClient.deadHandArrayMaps(
               'worldApps',
               [firstApp.entityMap.arrayIndexId],
               realms.playerId,
             );
             targetRealm.emitUpdate(deadHandUpdate);
+            */
 
             // add at the new location (world)
             const firstAppJson = firstApp.toObject();
@@ -471,12 +481,16 @@ export const startGame = async ({
             realms.localPlayer.playerApps.removeEntityAt(appId);
             realms.localPlayer.playerActions.removeEntityAt(firstAction.arrayIndexId);
 
+            // livehand
+            // Is emitted by addEntity().
+            /*
             const liveHandUpdate = targetRealm.dataClient.liveHandArrayMap(
               'worldApps',
               [firstApp.entityMap.arrayIndexId],
               realms.playerId,
             );
             targetRealm.emitUpdate(liveHandUpdate);
+            */
 
           } else {
             console.warn('no containing realm to drop to');

--- a/public/game.js
+++ b/public/game.js
@@ -355,8 +355,8 @@ export const startGame = async ({
     // action methods
     const _pickupDrop = () => {
       // console.log('drop 1');
-      const position = localPlayerCanvas.virtualPlayer.getKey('position');
-      const direction = localPlayerCanvas.virtualPlayer.getKey('direction');
+      const position = localPlayerCanvas.virtualPlayer.getKeyValue('position');
+      const direction = localPlayerCanvas.virtualPlayer.getKeyValue('direction');
       const targetPosition = [
         position[0] + direction[0] * frameSize,
         0,
@@ -749,7 +749,7 @@ export const startGame = async ({
         _renderRealms();
 
         // update realms set
-        const position = realms.localPlayer.getKey('position');
+        const position = realms.localPlayer.getKeyValue('position');
         realms.updatePosition(position, realmSize, {
           // onConnect,
         });

--- a/public/game.js
+++ b/public/game.js
@@ -73,44 +73,17 @@ export const startGame = async ({
   realms.addEventListener('realmjoin', e => {
     const {realm} = e.data;
     
-    const {dataClient, networkedDataClient} = realm;
+    const {dataClient} = realm;
 
     // console.log('realm join', realm.key);
     
-    const onsyn = e => {
-      const {synId} = e.data;
-      // console.log('response synAck', synId);
-      const synAckMessage = dataClient.getSynAckMessage(synId);
-      networkedDataClient.emitUpdate(synAckMessage);
-    };
-    dataClient.addEventListener('syn', onsyn);
-
-    const cleanupFns = [
-      () => {
-        dataClient.removeEventListener('syn', onsyn);
-      },
-    ];
+    const cleanupFns = [];
     
     const el = getRealmElement(realm);
     if (el) {
       el.classList.add('connected');
       el.classList.remove('connecting');
       
-      /* setInterval(() => {
-        console.log('send syn');
-        const synMessage = dataClient.getSynMessage();
-        networkedDataClient.emitUpdate(synMessage);
-      }, 2 * 1000); */
-
-      /* window.sync = synId => {
-        const synMessage = dataClient.getSynMessage(synId);
-        networkedDataClient.emitUpdate(synMessage);
-      }; */
-
-      /* this.addEventListener('synAck', e => {
-        console.log('got synack', e.data);
-      }); */
-
       el.updateText(dataClient);
 
       const playersArray = dataClient.getArray('players');

--- a/public/game.js
+++ b/public/game.js
@@ -153,8 +153,8 @@ export const startGame = async ({
       virtualWorld.worldApps.addEventListener('needledentityremove', onentityremove3);
   
       cleanupFns.push(() => {
-        dataClient.removeEventListener('add', onadd);
-        dataClient.removeEventListener('remove', onremove);
+        playersArray.removeEventListener('add', onadd);
+        playersArray.removeEventListener('remove', onremove);
         virtualWorld.worldApps.removeEventListener('needledentityadd', onentityadd3);
         virtualWorld.worldApps.removeEventListener('needledentityremove', onentityremove3);
 

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1,6 +1,6 @@
 import {DataClient, NetworkedDataClient, DCMap, DCArray} from './data-client.mjs';
 import {NetworkedIrcClient} from './irc-client.mjs';
-import {NetworkedAudioClient, createMicrophoneSource} from './audio-client.mjs';
+import {NetworkedAudioClient, initAudioContext, createMicrophoneSource} from './audio-client.mjs';
 import {
   createWs,
   makePromise,
@@ -1381,6 +1381,11 @@ export class NetworkRealms extends EventTarget {
       }
     });
     await Promise.all(promises);
+  }
+
+  // Initializes the AudioContext.
+  initAudioContext() {
+    initAudioContext();
   }
 
   // Returns whether or not the player's microphone is enabled.

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1238,9 +1238,9 @@ export class NetworkRealms extends EventTarget {
       _importPlayer();
 
       // migrate networked audio client
-      realms.migrateAudioRealm(oldHeadRealm, newHeadRealm);
+      this.migrateAudioRealm(oldHeadRealm, newHeadRealm);
 
-      await realms.sync();
+      await this.sync();
 
       // delete old
       // delete apps

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1155,7 +1155,26 @@ class VirtualWorld extends EventTarget {
 
 //
 
+// The set of network realms at and surrounding the player's current location.
+// Properties:
+// - localPlayer - The user's player object.
+// Events:
+// - realmconnecting - MessageEvent fired when a connection to a new realm is being established. Event data contains the
+//    NetworkRealm being connected to.
+// - realmjoin - MessageEvent fired when a connection to a new realm has been established. Event data contains the NetworkRealm
+//    that has been connected to.
+// - realmleave - MessageEvent fired when a connection to an old realm has been removed. Event data contains the NetworkRealm
+//    that has been disconnected from.
+// - networkreconfigure - MessageEvent fired when the set of realms connected to changes. Event data is empty.
+// - micenabled - MessageEvent fired when the player's microphone is enabled. Event data is empty.
+// - micdisabled - MessageEvent fired when the player's microphone is disabled. Event data is empty.
+// - chat - MessageEvent fired when a chat message is receive from a remote player in the realms. Event data contains the chat
+//    message.
 export class NetworkRealms extends EventTarget {
+  // The 'chat' event is dispatched within VirtualIrc.
+
+  // Constructs a NetworkRealms object and connects the local player to multiplayer.
+  // - playerId - A unique string identifying the local player.
   constructor(playerId) {
     super();
 
@@ -1281,14 +1300,18 @@ export class NetworkRealms extends EventTarget {
     this.tx = makeTransactionHandler();
   }
 
+  // Gets the other players also present in the local player's NetworkRealms.
   getVirtualPlayers() {
     return this.players;
   }
 
+  // Gets the world of apps present in the local player's NetworkRealms.
   getVirtualWorld() {
     return this.world;
   }
 
+  // Gets the realm connected to at the player's position.
+  // Returns: The NetworkRealm at the player's position if there is one connected to, null if there's none.
   getClosestRealm(position) {
     for (const realm of this.connectedRealms) {
       if (realm.connected) {
@@ -1308,6 +1331,7 @@ export class NetworkRealms extends EventTarget {
     return null;
   }
 
+  // Internal method.
   async sync() {
     // for all realms
     const promises = Array.from(this.connectedRealms.values()).map(async realm => {
@@ -1357,10 +1381,12 @@ export class NetworkRealms extends EventTarget {
     await Promise.all(promises);
   }
 
+  // Returns whether or not the player's microphone is enabled.
   isMicEnabled() {
     return !!this.microphoneSource;
   }
 
+  // Toggles the player's microphone on/off.
   toggleMic() {
     if (!this.isMicEnabled()) {
       this.enableMic();
@@ -1369,6 +1395,7 @@ export class NetworkRealms extends EventTarget {
     }
   }
 
+  // Enables the player's microphone.
   async enableMic() {
     if (!this.microphoneSource) {
       this.microphoneSource = await createMicrophoneSource();
@@ -1389,6 +1416,7 @@ export class NetworkRealms extends EventTarget {
     }
   }
 
+  // Disables the player's microphone.
   disableMic() {
     if (this.microphoneSource) {
       const headRealm = this.localPlayer.headTracker.getHeadRealm();
@@ -1407,6 +1435,7 @@ export class NetworkRealms extends EventTarget {
     }
   }
 
+  // Internal method.
   migrateAudioRealm(oldRealm, newRealm) {
     if (this.microphoneSource) {
       const {networkedAudioClient: oldNetworkedAudioClient} = oldRealm;
@@ -1416,11 +1445,16 @@ export class NetworkRealms extends EventTarget {
     }
   }
 
+  // Sends a chat message to the realm that the local player is in.
+  // - message - String to send.  
   sendChatMessage(message) {
     const headRealm = this.localPlayer.headTracker.getHeadRealm();
     headRealm.sendChatMessage(message);
   }
 
+  // Updates the set of realms connected to based on the local player's position.
+  // - position: The local player's position.
+  // - realmsize: The size of the x and z dimensions of realms.
   async updatePosition(position, realmSize, {
     onConnect,
   } = {}) {

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1199,10 +1199,16 @@ export class NetworkRealms extends EventTarget {
 
     // Provide entity add/remove events.
     this.appsEntityTracker.addEventListener('entityadd', e => {
-      this.dispatchEvent(new MessageEvent('entityadd', {data: e.data}));
+      // Add to the event queue after allowing internal event handlers to have been called.
+      setTimeout(() => {
+        this.dispatchEvent(new MessageEvent('entityadd', {data: e.data}));
+      }, 0);
     });
     this.appsEntityTracker.addEventListener('entityremove', e => {
-      this.dispatchEvent(new MessageEvent('entityremove', {data: e.data}));
+      // Add to the event queue after allowing internal event handlers to have been called.
+      setTimeout(() => {
+        this.dispatchEvent(new MessageEvent('entityremove', {data: e.data}));
+      }, 0);
     });
 
     this.players = new VirtualPlayersArray('players', this, {

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1563,4 +1563,22 @@ export class NetworkRealms extends EventTarget {
       });
     }
   }
+
+  // Disconnects the local player from multiplayer.
+  disconnect() {
+    for (const connectedRealm of this.connectedRealms) {
+      connectedRealm.disconnect();
+      connectedRealm.flush();
+      this.players.unlink(connectedRealm);
+      this.localPlayer.unlink(connectedRealm);
+      this.world.unlink(connectedRealm);
+      this.irc.unlink(connectedRealm);
+      this.connectedRealms.delete(connectedRealm);
+      this.dispatchEvent(new MessageEvent('realmleave', {
+        data: {
+          realm: connectedRealm,
+        },
+      }));
+    }
+  }
 }

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1195,6 +1195,14 @@ export class NetworkRealms extends EventTarget {
       entityTracker: this.appsEntityTracker,
     });
 
+    // Provide entity add/remove events.
+    this.appsEntityTracker.addEventListener('entityadd', e => {
+      this.dispatchEvent(new MessageEvent('entityadd', {data: e.data}));
+    });
+    this.appsEntityTracker.addEventListener('entityremove', e => {
+      this.dispatchEvent(new MessageEvent('entityremove', {data: e.data}));
+    });
+
     this.players = new VirtualPlayersArray('players', this, {
       appsEntityTracker: this.appsEntityTracker,
     });

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -767,6 +767,10 @@ class VirtualEntityArray extends VirtualPlayersArray {
     return map;
   }
 
+  removeEntityAt(arrayIndexId) {
+    this.getVirtualMap(arrayIndexId).remove();
+  }
+
   getSize() {
     return this.entityTracker.getSize();
   }

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -480,6 +480,9 @@ class VirtualPlayer extends HeadTrackedEntity {
     this.playerActions.link(realm);
 
     // link initial position
+    if (!this.headTracker.isLinked()) {
+      this.dispatchEvent(new MessageEvent('join'));
+    }
     this.headTracker.linkRealm(realm);
 
     // cleanup

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -506,7 +506,7 @@ class VirtualPlayer extends HeadTrackedEntity {
     }
   }
 
-  getKey(key) {
+  getKeyValue(key) {
     const headRealm = this.headTracker.getHeadRealm();
     const {dataClient} = headRealm;
     const valueMap = dataClient.getArrayMap(this.arrayId, this.arrayIndexId, {

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1562,7 +1562,7 @@ export class NetworkRealms extends EventTarget {
 
         // if this is the first network configuration, initialize our local player
         if (oldNumConnectedRealms === 0 && connectPromises.length > 0) {
-          onConnect && onConnect(position);
+          onConnect && await onConnect(position);
         }
         // we are in the middle of a network configuration, so take the opportunity to migrate the local player if necessary
         await this.localPlayer.headTracker.tryMigrate(position);

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1119,8 +1119,12 @@ export class NetworkRealm extends EventTarget {
   }
 
   disconnect() {
+    this.dispatchEvent(new Event('disconnecting'));
+
     this.ws.close();
     this.connected = false;
+
+    this.dispatchEvent(new Event('disconnect'));
   }
 
   emitUpdate(update) {

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1050,6 +1050,8 @@ export class NetworkRealm extends EventTarget {
   }
 
   async connect() {
+    this.dispatchEvent(new Event('connecting'));
+
     const ws1 = createWs('realm:' + this.key, this.parent.playerId);
     ws1.binaryType = 'arraybuffer';
     this.ws = ws1;
@@ -1069,6 +1071,8 @@ export class NetworkRealm extends EventTarget {
       }),
     ]);
     this.connected = true;
+
+    this.dispatchEvent(new Event('connect'));
   }
 
   * getClearUpdateFns() {
@@ -1445,7 +1449,6 @@ export class NetworkRealms extends EventTarget {
           }
 
           if (!foundRealm) {
-            realm.dispatchEvent(new Event('connecting'));
             this.dispatchEvent(new MessageEvent('realmconnecting', {
               data: {
                 realm,
@@ -1462,8 +1465,6 @@ export class NetworkRealms extends EventTarget {
 
               this.connectedRealms.add(realm);
 
-              // emit event
-              realm.dispatchEvent(new Event('connect'));
               this.dispatchEvent(new MessageEvent('realmjoin', {
                 data: {
                   realm,

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -497,6 +497,10 @@ class VirtualPlayer extends HeadTrackedEntity {
   unlink(realm) {
     this.cleanupMapFns.get(realm)();
     this.cleanupMapFns.delete(realm);
+
+    if (!this.headTracker.isLinked()) {
+      this.dispatchEvent(new MessageEvent('leave'));
+    }
   }
 
   getKey(key) {
@@ -586,6 +590,7 @@ class VirtualPlayersArray extends EventTarget {
           }
         }
       };
+
       const _unlinkPlayer = arrayIndexId => {
         const playerId = arrayIndexId;
 
@@ -601,7 +606,6 @@ class VirtualPlayersArray extends EventTarget {
             if (!virtualPlayer.headTracker.isLinked()) {
               this.virtualPlayers.delete(playerId);
 
-              virtualPlayer.dispatchEvent(new MessageEvent('leave'));
               this.dispatchEvent(new MessageEvent('leave', {
                 data: {
                   player: virtualPlayer,

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -1023,14 +1023,14 @@ class NeedledVirtualEntityMap extends HeadTrackedEntity {
 //
 
 export class NetworkRealm extends EventTarget {
-  constructor(min, size, parent) {
+  constructor(id, min, size, parent) {
     super();
 
     this.min = min;
     this.size = size;
     this.parent = parent;
 
-    this.key = min.join(':');
+    this.key = id + ':' + min.join(':');
     this.connected = false;
 
     const dc1 = new DataClient({
@@ -1155,7 +1155,7 @@ class VirtualWorld extends EventTarget {
 
 //
 
-// The set of network realms at and surrounding the player's current location.
+// The set of network realms at and surrounding the player's current location in the current scene.
 // Properties:
 // - localPlayer - The user's player object.
 // Events:
@@ -1174,10 +1174,12 @@ export class NetworkRealms extends EventTarget {
   // The 'chat' event is dispatched within VirtualIrc.
 
   // Constructs a NetworkRealms object and connects the local player to multiplayer.
-  // - playerId - A unique string identifying the local player.
-  constructor(playerId) {
+  // - sceneId - A unique alphanumeric string identifying the scene.
+  // - playerId - A unique alphanumeric string identifying the local player.
+  constructor(sceneId, playerId) {
     super();
 
+    this.sceneId = sceneId;
     this.playerId = playerId;
 
     this.lastPosition = [NaN, NaN, NaN];
@@ -1477,7 +1479,7 @@ export class NetworkRealms extends EventTarget {
               0,
               Math.floor((snappedPosition[2] + dz * realmSize) / realmSize) * realmSize,
             ];
-            const realm = new NetworkRealm(min, realmSize, this);
+            const realm = new NetworkRealm(this.sceneId, min, realmSize, this);
             candidateRealms.push(realm);
           }
         }

--- a/public/network-realms.mjs
+++ b/public/network-realms.mjs
@@ -278,6 +278,7 @@ class EntityTracker extends EventTarget {
 
           this.dispatchEvent(new MessageEvent('entityremove', {
             data: {
+              arrayId: map.arrayId,
               entityId: arrayIndexId,
               entity: virtualMap,
             },
@@ -297,6 +298,7 @@ class EntityTracker extends EventTarget {
     if (added) {
       this.dispatchEvent(new MessageEvent('entityadd', {
         data: {
+          arrayId: map.arrayId,
           entityId: map.arrayIndexId,
           entity: virtualMap,
         },

--- a/public/renderers/html-renderer.js
+++ b/public/renderers/html-renderer.js
@@ -392,8 +392,8 @@ export class GamePlayerCanvas {
     };
   }
   move() {
-    const oldPosition = this.virtualPlayer.getKey('position');
-    const oldDirection = this.virtualPlayer.getKey('direction');
+    const oldPosition = this.virtualPlayer.getKeyValue('position');
+    const oldDirection = this.virtualPlayer.getKeyValue('direction');
     
     const speed = 5;
 
@@ -445,7 +445,7 @@ export class GamePlayerCanvas {
   }
   draw() {
     if (GamePlayerCanvas.#spriteImg) {
-      const direction = this.virtualPlayer.getKey('direction');
+      const direction = this.virtualPlayer.getKeyValue('direction');
 
       let row;
       if (direction[0] === -1) {
@@ -465,8 +465,8 @@ export class GamePlayerCanvas {
       this.ctx.drawImage(GamePlayerCanvas.#spriteImg, col * frameSize, row * frameSize, frameSize, frameSize, 0, 0, frameSize, frameSize);
     
       if (!this.local) {
-        const remotePlayerPosition = this.virtualPlayer.getKey('position');
-        // const localPlayerPosition = realms.localPlayer.getKey('position');
+        const remotePlayerPosition = this.virtualPlayer.getKeyValue('position');
+        // const localPlayerPosition = realms.localPlayer.getKeyValue('position');
 
         this.element.style.transform = `translate3d(${remotePlayerPosition[0]}px, ${remotePlayerPosition[2]}px, 0)`;
       }

--- a/public/util.mjs
+++ b/public/util.mjs
@@ -1,3 +1,4 @@
+import {MULTIPLAYER_PORT} from './constants.js';
 import {zbencode, zbdecode} from './encoding.mjs';
 import {UPDATE_METHODS} from './update-types.js';
 
@@ -200,8 +201,17 @@ function serializeMessage(m) {
 }
 
 const createWs = (roomname, playerId) => {
-  const wss = document.location.protocol === 'http:' ? 'ws://' : 'wss://';
-  const ws = new WebSocket(wss + location.host + '/api/room/' + roomname + '/websocket?playerId=' + playerId);
+  let wss = document.location.protocol === 'http:' ? 'ws://' : 'wss://';
+  let hostname = location.hostname;
+
+  // The local development server's WebSocket is provided at ws://localhost.
+  const isDevelopment = location.hostname === 'local.webaverse.com';
+  if (isDevelopment) {
+    wss = 'ws://';
+    hostname = 'localhost'
+  }
+
+  const ws = new WebSocket(`${wss}${hostname}:${MULTIPLAYER_PORT}/api/room/${roomname}/websocket?playerId=${playerId}`);
   /* ws.waitForConnect = async () => {
     return new Promise((accept, reject) => {
       ws.onopen = () => {


### PR DESCRIPTION
This PR makes changes needed for multiplayer to be integrated into the Webaverse app per: https://github.com/upstreet-labs/app/pull/250

The following PRs are merged into this branch:
- Fix use of global realms reference: https://github.com/webaverse/multiplayer-do/pull/3
- Remove unused sendChatMessage() method from audio-client code: https://github.com/webaverse/multiplayer-do/pull/4
- Improve events: https://github.com/webaverse/multiplayer-do/pull/6

Additionally, the following changes have been made:
- Make the local development server able to be found by the Webavserse app.
- Fix clean-up when leaving realms.
- Add disconnect method.
- Support separate realm sets for different scenes.
- Audio initialization fixes.
- Move internal networking code into library.
- Support async onConnect callback.
- Add removeEntityAt() method.
- Remove duplicate events.
- Provide entityadd and entityremove events in NetworkRealms API.
- Include arrayId in entityadd and entityremove events.
- Make external entityadd and entityremove events occurr after internal processing.
